### PR TITLE
ascii-65: one param for mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,9 @@ Customize the `plot` function with a variety of settings:
 | `thresholds`     | Defines threshold lines or points with optional colors at specific x or y coordinates.                        |
 | `points`         | Defines points with optional colors at specific x or y coordinates.                                           |
 | `fillArea`       | Fills the area under each line, suitable for area charts.                                                     |
-| `barChart`       | Draws bar chart.                                                                                              |
-| `horizontalBarChart`| Draws horizontal bar chart.                                                                                |
 | `hideXAxis`      | Hides the x-axis.                                                                                             |
 | `hideYAxis`      | Hides the y-axis.                                                                                             |
+| `mode`           | Sets the plotting mode (line, point, bar, horizontal bar), defaults to line                                   |
 | `symbols`        | Symbols for customizing the chart’s appearance, including axis, background, and chart symbols.                |
 | `legend`         | Configuration for a legend, showing series names and position options (`left`, `right`, `top`, `bottom`).     |
 | `debugMode`      | Enables debug mode (`default = false`).                                                                       |
@@ -1064,7 +1063,7 @@ plot(
 ],
 {
   title: 'bar chart with axis',
-  barChart: true,
+  mode: 'bar',
   showTickLabel: true,
   width: 40,
   axisCenter: [0, 0],
@@ -1107,7 +1106,7 @@ plot(
     [7, 0],
   ],
   {
-    horizontalBarChart: true,
+    mode: 'horizontalBar',
     showTickLabel: true,
     width: 40,
     height: 20,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-ascii-chart",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Simple ascii chart generator",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -16,7 +16,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
       [3, 4],
       [4, 1],
     ],
-    { title: 'bar chart', width: 10, barChart: true, height: 10 },
+    { title: 'bar chart', width: 10, mode: 'bar', height: 10 },
   ],
   [
     [
@@ -25,7 +25,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
       [3, 4],
       [4, 1],
     ],
-    { title: 'horizontal bar chart', width: 20, horizontalBarChart: true, height: 10 },
+    { title: 'horizontal bar chart', width: 20, mode: 'horizontalBar', height: 10 },
   ],
   [
     [
@@ -101,9 +101,42 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
 
     {
       title: 'multiline',
-      width: 20,
+      width: 50,
+    },
+  ],
+  [
+    [
+      [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 1],
+      ],
+      [
+        [1, -2],
+        [2, -3],
+        [3, 3],
+        [4, 0],
+      ],
+      [
+        [1, -6],
+        [2, -3],
+        [3, 3],
+        [4, 0],
+      ],
+      [
+        [1, -2],
+        [2, -3],
+        [3, 3],
+        [4, 0],
+        [5, 3],
+      ],
+    ],
 
-      height: 10,
+    {
+      title: 'multiline points',
+      width: 50,
+      mode: 'point',
     },
   ],
   [
@@ -415,7 +448,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
     {
       title: 'bar chart with colors',
       color: 'ansiGreen',
-      barChart: true,
+      mode: 'bar',
       showTickLabel: true,
       width: 40,
       axisCenter: [0, 0],
@@ -434,7 +467,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
     ],
     {
       title: 'horizontal bar chart with axis center',
-      horizontalBarChart: true,
+      mode: 'horizontalBar',
       showTickLabel: true,
       width: 40,
       height: 20,
@@ -447,7 +480,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
       [2, 20],
       [3, 29],
     ],
-    { height: 10, horizontalBarChart: true, width: 20, showTickLabel: true },
+    { height: 10, mode: 'horizontalBar', width: 20, showTickLabel: true },
   ],
   [
     [
@@ -455,7 +488,7 @@ const examples: Array<[Coordinates, Settings & { only?: boolean }]> = [
       [2, 20],
       [3, 29],
     ],
-    { height: 10, barChart: true, width: 20, showTickLabel: true },
+    { height: 10, mode: 'bar', width: 20, showTickLabel: true },
   ],
 ];
 

--- a/src/services/__tests__/draw.test.ts
+++ b/src/services/__tests__/draw.test.ts
@@ -10,7 +10,7 @@ import {
   drawPosition,
 } from '../draw';
 import { AXIS, CHART } from '../../constants';
-import { MultiLine, Point } from '../../types';
+import { GraphMode, MultiLine, Point } from '../../types';
 
 describe('Drawing functions', () => {
   describe('drawPosition', () => {
@@ -271,8 +271,7 @@ describe('Drawing functions', () => {
           [1, 1],
         ] as Point[],
         graph,
-        horizontalBarChart: false,
-        barChart: false,
+        mode: 'line' as GraphMode,
         scaledX: 1,
         axis: { x: 0, y: 5 },
         axisCenter: undefined,

--- a/src/services/__tests__/plot.test.ts
+++ b/src/services/__tests__/plot.test.ts
@@ -440,7 +440,7 @@ s-30┤━━━━━━━━━━━━━━━━━━┛
         [2, 20],
         [3, 29],
       ],
-      { height: 10, barChart: true, width: 20, showTickLabel: true },
+      { height: 10, mode: 'bar', width: 20, showTickLabel: true },
       `
   ▲                   █ 
 26┤                   █ 
@@ -464,7 +464,7 @@ s-30┤━━━━━━━━━━━━━━━━━━┛
         [2, 20],
         [3, 29],
       ],
-      { height: 10, horizontalBarChart: true, width: 20, showTickLabel: true },
+      { height: 10, mode: 'horizontalBar', width: 20, showTickLabel: true },
       `
   ▲                     
 26┤███████████████████  
@@ -494,7 +494,7 @@ s-30┤━━━━━━━━━━━━━━━━━━┛
         [7, 0],
       ],
       {
-        horizontalBarChart: true,
+        mode: 'horizontalBar',
         showTickLabel: true,
         width: 40,
         height: 20,
@@ -568,7 +568,7 @@ s-30┤━━━━━━━━━━━━━━━━━━┛
       ],
       {
         title: 'bar chart with axis',
-        barChart: true,
+        mode: 'bar',
         showTickLabel: true,
         width: 40,
         axisCenter: [0, 0],
@@ -1402,6 +1402,32 @@ verylongtitleverylongtitleverylongtitleverylongtitleverylongtitleverylongtitleve
 1┤┛  
  └┬┬▶
   12 
+`,
+    ],
+    [
+      'plot with points',
+      [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 1],
+      ],
+      { title: 'Points', width: 10, mode: 'point', height: 10 },
+      `
+Points       
+ ▲           
+4┤      ●    
+ │           
+ │           
+3┤   ●       
+ │           
+ │           
+2┤●          
+ │           
+ │           
+1┤         ● 
+ └┬──┬──┬──┬▶
+  1  2  3  4 
 `,
     ],
     [

--- a/src/services/draw.ts
+++ b/src/services/draw.ts
@@ -1,8 +1,9 @@
-import { AXIS, CHART } from '../constants';
+import { AXIS, CHART, POINT } from '../constants';
 import {
   CustomSymbol,
   Formatter,
   Graph,
+  GraphMode,
   LineFormatterArgs,
   MaybePoint,
   MultiLine,
@@ -427,8 +428,6 @@ export const drawCustomLine = ({
  * @param {Graph} params.graph - The graph matrix to modify.
  * @param {number} params.scaledX - X-axis scaling.
  * @param {number} params.scaledY - Y-axis scaling.
- * @param {boolean} params.horizontalBarChart - Whether to fill the width of the bars.
- * @param {boolean} params.barChart - Whether to fill the width of the bars.
  * @param {number} params.plotHeight - Height of the plot area.
  * @param {string} params.emptySymbol - Symbol used to fill empty cells.
  * @param {Object} params.axis - Axis position.
@@ -436,6 +435,7 @@ export const drawCustomLine = ({
  * @param {MaybePoint} params.axisCenter - Axis position selected by user.
  * @param {number} params.axis.x - X-position of the Y-axis on the graph.
  * @param {number} params.axis.y - Y-position of the X-axis on the graph.
+ * @param {string} params.mode - Graph mode (e.g., 'line', 'point').
  * @param {boolean} [params.debugMode=false] - If true, logs errors for out-of-bounds access.
  */
 export const drawLine = ({
@@ -447,11 +447,10 @@ export const drawLine = ({
   plotHeight,
   emptySymbol,
   chartSymbols,
-  horizontalBarChart,
-  barChart,
   axisCenter,
   debugMode,
   axis,
+  mode,
 }: {
   index: number;
   arr: Point[];
@@ -461,18 +460,17 @@ export const drawLine = ({
   plotHeight: number;
   emptySymbol: string;
   chartSymbols: Symbols['chart'];
-  horizontalBarChart?: boolean;
-  barChart?: boolean;
   axisCenter: MaybePoint;
   axis: { x: number; y: number };
   debugMode?: boolean;
+  mode: GraphMode;
 }) => {
   const [currX, currY] = arr[index];
-  if (barChart || horizontalBarChart) {
+  if (mode === 'bar' || mode === 'horizontalBar') {
     const positions: [number, number][] = [];
     const axisCenterShift = axisCenter ? 0 : 1;
     // For vertical bar chart
-    if (barChart) {
+    if (mode === 'bar') {
       let i;
       // Check if the value is positive or negative
       if (scaledY >= axis.y) {
@@ -493,7 +491,7 @@ export const drawLine = ({
     }
 
     // For horizontal bar chart
-    if (horizontalBarChart) {
+    if (mode === 'horizontalBar') {
       let i;
       if (scaledX >= axis.x) {
         // For positive values, draw rightward from the value to the axis
@@ -523,6 +521,17 @@ export const drawLine = ({
       });
     });
 
+    return;
+  }
+
+  if (mode === 'point') {
+    drawPosition({
+      debugMode,
+      graph,
+      scaledX: scaledX + 1,
+      scaledY: scaledY + 1,
+      symbol: POINT,
+    });
     return;
   }
 

--- a/src/services/plot.ts
+++ b/src/services/plot.ts
@@ -41,8 +41,6 @@ export const plot: Plot = (
     symbols,
     title,
     fillArea,
-    horizontalBarChart,
-    barChart,
     hideXAxis,
     hideYAxis,
     xLabel,
@@ -51,6 +49,7 @@ export const plot: Plot = (
     thresholds,
     points,
     debugMode,
+    mode = 'line',
   } = {},
 ) => {
   // Multiline
@@ -109,6 +108,7 @@ export const plot: Plot = (
         const [scaledX, scaledY] = toPlotCoordinates(x, y);
         if (!lineFormatter) {
           drawLine({
+            mode,
             debugMode,
             index,
             arr,
@@ -118,10 +118,8 @@ export const plot: Plot = (
             plotHeight,
             emptySymbol,
             chartSymbols,
-            horizontalBarChart,
             axis,
             axisCenter,
-            barChart,
           });
 
           // fill empty area under the line if fill area is true

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,14 @@ export type Colors = Color | Color[] | ColorGetter;
 export type Graph = string[][];
 
 /**
+ * Graph mode options for rendering the graph.
+ * 'line' mode connects points with lines.
+ * 'point' mode displays points without connecting lines.
+ * line is the default mode.
+ */
+export type GraphMode = 'line' | 'point' | 'bar' | 'horizontalBar';
+
+/**
  * Configuration settings for rendering a plot.
  */
 export type Settings = {
@@ -147,13 +155,12 @@ export type Settings = {
   thresholds?: Threshold[]; // Array of threshold lines
   points?: GraphPoint[]; // Array of points to plot
   fillArea?: boolean; // Option to fill the area under lines
-  horizontalBarChart?: boolean; // Option to draw horizontal bar chart
-  barChart?: boolean; // Option to draw bar chart
   legend?: Legend; // Legend settings
   axisCenter?: MaybePoint; // Center point for axes alignment
   formatter?: Formatter; // Custom formatter for axis values
   lineFormatter?: (args: LineFormatterArgs) => CustomSymbol | CustomSymbol[]; // Custom line formatter
   symbols?: Symbols; // Custom symbols for chart elements
+  mode?: GraphMode; // Option to enable debug mode
   debugMode?: boolean; // Option to enable debug mode
 };
 


### PR DESCRIPTION
One param for mode - instead of barChart and horizontalBarChart now it's mode:
export type GraphMode = 'line' | 'point' | 'bar' | 'horizontalBar';
